### PR TITLE
pre-release pipeline fixes

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -197,6 +197,7 @@ jobs:
           mvn \
             --batch-mode \
             --define ci-build \
+            --projects ${{ matrix.project }} \
             package
 
       - name: Upload Maven State
@@ -277,9 +278,9 @@ jobs:
         run: |
           cd advent-of-code-2022
           mvn \
-            --projects ${{ matrix.project }} \
             --batch-mode \
             --define ci-test \
+            --projects ${{ matrix.project }} \
             package
 
       - name: Upload Test Report


### PR DESCRIPTION
- build-step of pre-release pipeline now builds each sub-project sepaately
- same order of parameters on all mvn-commands